### PR TITLE
fix string casts

### DIFF
--- a/main.v
+++ b/main.v
@@ -19,7 +19,7 @@ fn test_timeout(ctx &vmq.Context) ? {
 	p2.connect('inproc://timeouttest') ?
 	p1.send('but that\'s ok, we set a timeout!'.bytes()) ?
 
-	println(string(p2.recv()?))
+	println(p2.recv()?.bytestr())
 }
 
 fn test_pubsub(ctx &vmq.Context) ? {
@@ -36,10 +36,10 @@ fn test_pubsub(ctx &vmq.Context) ? {
 	p.send('[topic] hi (again)!'.bytes()) ?
 
 	m1 := s.recv()?
-	println(string(m1))
+	println(m1.bytestr())
 
 	m2 := s.recv()?
-	println(string(m2))
+	println(m2.bytestr())
 
 	s.unsubscribe('[topic]'.bytes())?
 	s.subscribe('[othertopic]'.bytes())?
@@ -49,7 +49,7 @@ fn test_pubsub(ctx &vmq.Context) ? {
 	p.send('[othertopic] hey world!'.bytes())?
 
 	m3 := s.recv()?
-	println(string(m3))
+	println(m3.bytestr())
 }
 
 fn test_pushpull(ctx &vmq.Context) ? {
@@ -77,5 +77,5 @@ fn recv(pull &vmq.Socket) {
 	msg := pull.recv() or {
 		panic(err)
 	}
-	println(string(msg))
+	println(msg.bytestr())
 }

--- a/modules/vmq/vmq.v
+++ b/modules/vmq/vmq.v
@@ -260,5 +260,5 @@ pub fn curve_keypair() ?(string, string) {
 		return error('ZMQ was not built with cryptographic support!')
 	}
 
-	return string(pub_buf), string(sec_buf)
+	return pub_buf.bytestr(), sec_buf.bytestr()
 }


### PR DESCRIPTION
just tried running the examples against V 0.2.4 105d7fc and realized that the string casts were not allowed anymore.